### PR TITLE
Token standard update

### DIFF
--- a/vhp/assembly/Vhp.ts
+++ b/vhp/assembly/Vhp.ts
@@ -77,7 +77,11 @@ export class Vhp {
     System.require(args.to != args.from, 'cannot transfer to yourself');
 
     let callerData = System.getCaller();
-    System.require(callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!), 'from has not authorized transfer');
+    System.require(
+      callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
+      'from has not authorized transfer',
+      error.error_code.authorization_failure
+    );
 
     let fromBalanceObj = System.getObject<Uint8Array, token.balance_object>(State.Space.BALANCE, args.from!, token.balance_object.decode);
 
@@ -86,7 +90,7 @@ export class Vhp {
       fromBalanceObj.value = 0;
     }
 
-    System.require(fromBalanceObj.value >= args.value, "account 'from' has insufficient balance");
+    System.require(fromBalanceObj.value >= args.value, "account 'from' has insufficient balance", error.error_code.failure);
 
     let toBalanceObj = System.getObject<Uint8Array, token.balance_object>(State.Space.BALANCE, args.to!, token.balance_object.decode);
 
@@ -124,7 +128,7 @@ export class Vhp {
         System.requireAuthority(authority.authorization_type.contract_call, Constants.CONTRACT_ID);
       }
       else {
-        System.revert('insufficient privileges to mint');
+        System.fail('insufficient privileges to mint', error.error_code.authorization_failure);
       }
     }
 
@@ -135,7 +139,7 @@ export class Vhp {
       supplyObject.value = 0;
     }
 
-    System.require(supplyObject.value <= u64.MAX_VALUE - args.value, 'mint would overflow supply');
+    System.require(supplyObject.value <= u64.MAX_VALUE - args.value, 'mint would overflow supply', error.error_code.failure);
 
     let balanceObject = System.getObject<Uint8Array, token.balance_object>(State.Space.BALANCE, args.to!, token.balance_object.decode);
 
@@ -166,7 +170,11 @@ export class Vhp {
     System.require(args.from != null, "burn argument 'from' cannot be null");
 
     let callerData = System.getCaller();
-    System.require(callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!), 'from has not authorized burn');
+    System.require(
+      callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
+      'from has not authorized burn',
+      error.error_code.authorization_failure
+    );
 
     let fromBalanceObject = System.getObject<Uint8Array, token.balance_object>(State.Space.BALANCE, args.from!, token.balance_object.decode);
 
@@ -175,7 +183,7 @@ export class Vhp {
       fromBalanceObject.value = 0;
     }
 
-    System.require(fromBalanceObject.value >= args.value, "account 'from' has insufficent balance");
+    System.require(fromBalanceObject.value >= args.value, "account 'from' has insufficent balance", error.error_code.failure);
 
     let supplyObject = System.getObject<Uint8Array, token.balance_object>(State.Space.SUPPLY, Constants.SUPPLY_KEY, token.balance_object.decode);
 
@@ -184,7 +192,7 @@ export class Vhp {
       supplyObject.value = 0;
     }
 
-    System.require(supplyObject.value >= args.value, 'burn would underflow supply');
+    System.require(supplyObject.value >= args.value, 'burn would underflow supply', error.error_code.failure);
 
     supplyObject.value -= args.value;
     fromBalanceObject.value -= args.value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,7 +1534,7 @@ koinos-proto-as@0.4.6:
 
 "koinos-sdk-as@https://github.com/koinos/koinos-sdk-as#testnet-4":
   version "0.4.11"
-  resolved "https://github.com/koinos/koinos-sdk-as#5183a6aa00c16187ed6177794bf1ae1bd93d0bb3"
+  resolved "https://github.com/koinos/koinos-sdk-as#73e87799c91f9a2da7af1fdaf61db2c9a7f8a401"
   dependencies:
     as-bignum "^0.2.18"
     as-proto "^0.2.2"


### PR DESCRIPTION
Resolves koinos/koinos-sdk-as#38.

## Brief description
Updates VHP token implement to adhere to new standard.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ node cli.js build vhp release
Compiling index.ts...
node ./node_modules/assemblyscript/bin/asc vhp/assembly/index.ts --target release --use abort= --use BUILD_FOR_TESTING=0 --config vhp/asconfig.json

=== RUN   TestVhp
    vhp_test.go:16: Generating key for alice
    vhp_test.go:20: Generating key for bob
    integration.go:569: Waiting 1s for chain to be ready...
    integration.go:569: Waiting 2s for chain to be ready...
    integration.go:569: Waiting 4s for chain to be ready...
    integration.go:569: Waiting 5s for chain to be ready...
    integration.go:569: Waiting 5s for chain to be ready...
    vhp_test.go:31: Uploading VHP contract
    vhp_test.go:35: Minting 1000 satoshis to alice
    vhp_test.go:45: Fail to transfer 1001 satoshi from alice to bob
    vhp_test.go:60: Fail to overflow 64-bit unsigned integer during mint
    vhp_test.go:75: Fail to burn more than balance
    vhp_test.go:93: Transferring 500 satoshi from alice to bob
    vhp_test.go:97: Ensuring total supply remains unchanged
    vhp_test.go:103: Minting 500 satoshis to bob
    vhp_test.go:110: Ensuring total supply is 1500
    vhp_test.go:113: Asserting alice's balance is 500
    vhp_test.go:119: Asserting bob's balance is 1000
    vhp_test.go:125: Burning 100 satoshi from bob's balance
    vhp_test.go:130: Ensuring total supply is 1400
    vhp_test.go:136: Asserting bob's balance is 900
--- PASS: TestVhp (19.42s)
PASS
ok  	koinos-integration-tests/tests/vhp	19.602s
```
