### PR TITLE
fix tests

### DIFF
--- a/contracts/vhp/as-pect.config.js
+++ b/contracts/vhp/as-pect.config.js
@@ -41,7 +41,7 @@ module.exports = {
       }
     };
     instance = instantiateSync(binary, createImports(myImports));
-    instance.exports.memory.grow(512);
+    instance.exports.memory.grow(8184);
     mockVM.setInstance(instance);
     return instance;
   },

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -184,7 +184,7 @@ export class Vhp {
       fromBalanceObject.value = 0;
     }
 
-    System.require(fromBalanceObject.value >= args.value, "account 'from' has insufficent balance");
+    System.require(fromBalanceObject.value >= args.value, "account 'from' has insufficient balance");
 
     let supplyObject = System.getObject<Uint8Array, token.balance_object>(State.Space.SUPPLY, Constants.SUPPLY_KEY, token.balance_object.decode);
 


### PR DESCRIPTION
## Brief description
Fix tests for VHP contract
I decided to use `setCaller` to set the kernel mode, but I saw you also have a `is_testing` argument for the contract's constructor, I wasn't sure which one to use.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```sh
[Describe]: vhp

 [Success]: ✔ should get the name RTrace: +28
 [Success]: ✔ should get the symbol RTrace: +28
 [Success]: ✔ should get the decimals RTrace: +24
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] vhp.burn / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EAo=
[Contract Exit] account 'from' has insufficient balance
[Contract Exit] from has not authorized burn
 [Success]: ✔ should/not burn tokens RTrace: +753
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
 [Success]: ✔ should mint tokens RTrace: +275
[Contract Exit] insufficient privileges to mint
 [Success]: ✔ should not mint tokens if not contract account RTrace: +166
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6EHs=
[Contract Exit] mint would overflow supply
 [Success]: ✔ should not mint tokens if new total supply overflows RTrace: +278
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] vhp.transfer / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAo=
 [Success]: ✔ should transfer tokens RTrace: +378
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] from has not authorized transfer
 [Success]: ✔ should not transfer tokens without the proper authorizations RTrace: +241
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] cannot transfer to yourself
 [Success]: ✔ should not transfer tokens to self RTrace: +231
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] account 'from' has insufficient balance
 [Success]: ✔ should not transfer if insufficient balance RTrace: +268

    [File]: assembly/__tests__/vhp.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 11 pass,  0 fail, 11 total
    [Time]: 3134.863ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 1 total
  [Groups]: 2 count, 2 pass
   [Tests]: 11 pass, 0 fail, 11 total
    [Time]: 13032.188ms
┌─────────────────┬───────┬───────┬──────┬──────┬───────────────────────────────┐
│ File            │ Total │ Block │ Func │ Expr │ Uncovered                     │
├─────────────────┼───────┼───────┼──────┼──────┼───────────────────────────────┤
│ assembly/Vhp.ts │ 87.9% │ 81.8% │ 100% │ 100% │ 93:26, 132:28, 182:36, 191:24 │
├─────────────────┼───────┼───────┼──────┼──────┼───────────────────────────────┤
│ total           │ 87.9% │ 81.8% │ 100% │ 100% │                               │
└─────────────────┴───────┴───────┴──────┴──────┴───────────────────────────────┘

Done in 13.53s.
```