### PR TITLE
Bad tests

### DIFF
--- a/contracts/vhp/as-pect.config.js
+++ b/contracts/vhp/as-pect.config.js
@@ -18,6 +18,7 @@ module.exports = {
     // "--textFile": ["output.wat"],
     /** A runtime must be provided here. */
     "--runtime": ["incremental"], // Acceptable values are: "incremental", "minimal", and "stub"
+    "-u":"BUILD_FOR_TESTING=1",
   },
   /**
    * A set of regexp that will disclude source files from testing.

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -21,10 +21,8 @@ namespace State {
 }
 
 export class Vhp {
-  private is_testing: bool;
 
-  constructor(is_testing: bool = false) {
-    this.is_testing = is_testing;
+  constructor() {
     Constants.CONTRACT_ID = System.getContractId();
     State.Space.SUPPLY = new chain.object_space(true, Constants.CONTRACT_ID, Constants.SUPPLY_ID);
     State.Space.BALANCE = new chain.object_space(true, Constants.CONTRACT_ID, Constants.BALANCE_ID);
@@ -129,7 +127,7 @@ export class Vhp {
     System.require(args.value != 0, "mint argument 'value' cannot be zero");
 
     if (System.getCaller().caller_privilege != chain.privilege.kernel_mode) {
-      if (this.is_testing) {
+      if (BUILD_FOR_TESTING) {
         System.requireAuthority(authority.authorization_type.contract_call, Constants.CONTRACT_ID);
       }
       else {

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -21,8 +21,10 @@ namespace State {
 }
 
 export class Vhp {
+  private is_testing: bool;
 
-  constructor() {
+  constructor(is_testing: bool = false) {
+    this.is_testing = is_testing;
     Constants.CONTRACT_ID = System.getContractId();
     State.Space.SUPPLY = new chain.object_space(true, Constants.CONTRACT_ID, Constants.SUPPLY_ID);
     State.Space.BALANCE = new chain.object_space(true, Constants.CONTRACT_ID, Constants.BALANCE_ID);
@@ -127,7 +129,7 @@ export class Vhp {
     System.require(args.value != 0, "mint argument 'value' cannot be zero");
 
     if (System.getCaller().caller_privilege != chain.privilege.kernel_mode) {
-      if (BUILD_FOR_TESTING) {
+      if (this.is_testing) {
         System.requireAuthority(authority.authorization_type.contract_call, Constants.CONTRACT_ID);
       }
       else {

--- a/contracts/vhp/assembly/index.ts
+++ b/contracts/vhp/assembly/index.ts
@@ -5,7 +5,7 @@ export function main(): i32 {
   const contractArgs = System.getArguments();
   let retbuf = new Uint8Array(1024);
 
-  const c = new ContractClass();
+  const c = new ContractClass(BUILD_FOR_ESTING);
 
   switch (contractArgs.entry_point) {
     case 0x82a3537f: {

--- a/contracts/vhp/assembly/index.ts
+++ b/contracts/vhp/assembly/index.ts
@@ -5,7 +5,7 @@ export function main(): i32 {
   const contractArgs = System.getArguments();
   let retbuf = new Uint8Array(1024);
 
-  const c = new ContractClass(BUILD_FOR_TESTING);
+  const c = new ContractClass();
 
   switch (contractArgs.entry_point) {
     case 0x82a3537f: {

--- a/contracts/vhp/assembly/index.ts
+++ b/contracts/vhp/assembly/index.ts
@@ -5,7 +5,7 @@ export function main(): i32 {
   const contractArgs = System.getArguments();
   let retbuf = new Uint8Array(1024);
 
-  const c = new ContractClass(BUILD_FOR_ESTING);
+  const c = new ContractClass();
 
   switch (contractArgs.entry_point) {
     case 0x82a3537f: {


### PR DESCRIPTION
Resolves #20

## Brief description

Increases VM memory, fixes tests, and adds `BUILD_FOR_TESTING` flag to `yarn test`

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
$ yarn test
yarn run v1.22.18
$ koinos-sdk-as-cli run-tests
Running tests...
yarn asp --verbose --config as-pect.config.js
$ /Users/mdv/git/koinos-system-contracts-as/contracts/vhp/node_modules/.bin/asp --verbose --config as-pect.config.js
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [6.2.4]

[Log] Loading asc compiler
Assemblyscript Folder:assemblyscript
[Log] Compiler loaded in 367.83ms.
[Log] Using configuration /Users/mdv/git/koinos-system-contracts-as/contracts/vhp/as-pect.config.js
[Log] Using VerboseReporter
[Log] Including files: assembly/__tests__/**/*.spec.ts
[Log] Running tests that match: (:?)
[Log] Running groups that match: (:?)
[Log] Effective command line args:
  [TestFile.ts] node_modules/@as-pect/assembly/assembly/index.ts --runtime incremental -u BUILD_FOR_TESTING=1 --debug --binaryFile output.wasm --explicitStart --use ASC_RTRACE=1 --exportTable --importMemory --transform /Users/mdv/git/koinos-system-contracts-as/contracts/vhp/node_modules/@as-covers/transform/lib/index.js,/Users/mdv/git/koinos-system-contracts-as/contracts/vhp/node_modules/@as-pect/core/lib/transform/index.js --lib node_modules/@as-covers/assembly/index.ts

[Describe]: vhp

 [Success]: ✔ should get the name RTrace: +28
 [Success]: ✔ should get the symbol RTrace: +28
 [Success]: ✔ should get the decimals RTrace: +24
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] vhp.burn / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EAo=
[Contract Exit] account 'from' has insufficient balance
[Contract Exit] from has not authorized burn
 [Success]: ✔ should/not burn tokens RTrace: +753
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
 [Success]: ✔ should mint tokens RTrace: +275
[Contract Exit] account '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqe' authorization failed
 [Success]: ✔ should not mint tokens if not contract account RTrace: +252
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6EHs=
[Contract Exit] mint would overflow supply
 [Success]: ✔ should not mint tokens if new total supply overflows RTrace: +278
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Event] vhp.transfer / [
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqK',
  '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG'
] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EhkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc6GAo=
 [Success]: ✔ should transfer tokens RTrace: +378
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] from has not authorized transfer
 [Success]: ✔ should not transfer tokens without the proper authorizations RTrace: +241
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] cannot transfer to yourself
 [Success]: ✔ should not transfer tokens to self RTrace: +231
[Event] vhp.mint / [ '1DQzuCcTKacbs9GGScRTU1Hc8BsyARTPqG' ] / ChkAiCtotTmdMTyQZ/OEFgfmKMEtVCA8jEc3EHs=
[Contract Exit] account 'from' has insufficient balance
 [Success]: ✔ should not transfer if insufficient balance RTrace: +268

    [File]: assembly/__tests__/vhp.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 11 pass,  0 fail, 11 total
    [Time]: 4091.583ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  [Result]: ✔ PASS
   [Files]: 1 total
  [Groups]: 2 count, 2 pass
   [Tests]: 11 pass, 0 fail, 11 total
    [Time]: 13762.149ms
┌─────────────────┬───────┬───────┬──────┬──────┬───────────────────────────────┐
│ File            │ Total │ Block │ Func │ Expr │ Uncovered                     │
├─────────────────┼───────┼───────┼──────┼──────┼───────────────────────────────┤
│ assembly/Vhp.ts │ 87.9% │ 81.8% │ 100% │ 100% │ 91:26, 133:12, 180:36, 189:24 │
├─────────────────┼───────┼───────┼──────┼──────┼───────────────────────────────┤
│ total           │ 87.9% │ 81.8% │ 100% │ 100% │                               │
└─────────────────┴───────┴───────┴──────┴──────┴───────────────────────────────┘

✨  Done in 14.62s.
```
