### PR TITLE
Uint8Array Comparison

### DIFF
--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -1,5 +1,5 @@
 import { authority, chain, protocol, system_call_ids, System, Protobuf,
-  Base58, value, error, system_calls, Token, SafeMath, token, Crypto } from "koinos-sdk-as";
+  Base58, value, error, system_calls, Token, SafeMath, token, Crypto, Arrays } from "koinos-sdk-as";
 
 namespace Constants {
   export const NAME = "Virtual Hash Power"
@@ -102,7 +102,7 @@ export class Vhp {
 
     let callerData = System.getCaller();
     System.require(
-      callerData.caller == args.from || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
+      Arrays.equal(callerData.caller, args.from) || System.checkAuthority(authority.authorization_type.contract_call, args.from!),
       'from has not authorized transfer',
       error.error_code.authorization_failure
     );

--- a/contracts/vhp/assembly/__tests__/vhp.spec.ts
+++ b/contracts/vhp/assembly/__tests__/vhp.spec.ts
@@ -400,4 +400,49 @@ describe("vhp", () => {
     // check error message
     expect(MockVM.getErrorMessage()).toBe("account 'from' has insufficient balance");
   });
+
+  it("should transfer tokens without authority", () => {
+    const tkn = new Vhp();
+
+    // set kernel mode
+    MockVM.setCaller(new chain.caller_data(new Uint8Array(0), chain.privilege.kernel_mode));
+
+    // set contract_call authority for CONTRACT_ID to true so that we can mint tokens
+    const authContractId = new MockVM.MockAuthority(authority.authorization_type.contract_call, CONTRACT_ID, true);
+    MockVM.setAuthorities([authContractId]);
+
+    // mint tokens
+    const mintArgs = new token.mint_arguments(MOCK_ACCT1, 123);
+    tkn.mint(mintArgs);
+
+    // set caller with MOCK_ACCT1 to allow transfer if the caller is the same from
+    MockVM.setCaller(new chain.caller_data(MOCK_ACCT1, chain.privilege.kernel_mode));
+
+    // transfer tokens
+    const transferArgs = new token.transfer_arguments(MOCK_ACCT1, MOCK_ACCT2, 10);
+    tkn.transfer(transferArgs);
+
+    // check balances
+    let balanceArgs = new token.balance_of_arguments(MOCK_ACCT1);
+    let balanceRes = tkn.balance_of(balanceArgs);
+    expect(balanceRes.value).toBe(113);
+
+    balanceArgs = new token.balance_of_arguments(MOCK_ACCT2);
+    balanceRes = tkn.balance_of(balanceArgs);
+    expect(balanceRes.value).toBe(10);
+
+    // check events
+    const events = MockVM.getEvents();
+    // 2 events, 1st one is the mint event, the second one is the transfer event
+    expect(events.length).toBe(2);
+    expect(events[1].name).toBe('vhp.transfer');
+    expect(events[1].impacted.length).toBe(2);
+    expect(Arrays.equal(events[1].impacted[0], MOCK_ACCT2)).toBe(true);
+    expect(Arrays.equal(events[1].impacted[1], MOCK_ACCT1)).toBe(true);
+
+    const transferEvent = Protobuf.decode<token.transfer_event>(events[1].data!, token.transfer_event.decode);
+    expect(Arrays.equal(transferEvent.from, MOCK_ACCT1)).toBe(true);
+    expect(Arrays.equal(transferEvent.to, MOCK_ACCT2)).toBe(true);
+    expect(transferEvent.value).toBe(10);
+  });
 });


### PR DESCRIPTION
Resolves #44 

## Brief description
should be allowed to transfer without the authority when the caller is the same as from

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
Add logs to verify the comparison of data in string and the result of these.
![image](https://user-images.githubusercontent.com/36174193/187798807-c15deeae-724c-4421-b0a6-61bd973e0495.png)

