### PR TITLE
Cleanup 0 value allowance objects in the KOIN and VHP contracts

### DIFF
--- a/contracts/koin/assembly/Koin.ts
+++ b/contracts/koin/assembly/Koin.ts
@@ -282,7 +282,7 @@ export class Koin {
 
       if (allowance.value == amount) {
         this.allowances.remove(key);
-        return true
+        return true;
       }
       else if (allowance.value > amount) {
         allowance.value -= amount;

--- a/contracts/koin/assembly/Koin.ts
+++ b/contracts/koin/assembly/Koin.ts
@@ -280,8 +280,10 @@ export class Koin {
       key.set(caller, 25);
       const allowance = this.allowances.get(key)!;
 
-      if (allowance.value == amount)
+      if (allowance.value == amount) {
         this.allowances.remove(key);
+        return true
+      }
       else if (allowance.value > amount) {
         allowance.value -= amount;
         this.allowances.put(key, allowance);

--- a/contracts/koin/assembly/Koin.ts
+++ b/contracts/koin/assembly/Koin.ts
@@ -257,7 +257,11 @@ export class Koin {
     const key = new Uint8Array(50);
     key.set(args.owner, 0);
     key.set(args.spender, 25);
-    this.allowances.put(key, new koin.balance_object(args.value));
+
+    if (args.value == 0)
+      this.allowances.remove(key);
+    else
+      this.allowances.put(key, new koin.balance_object(args.value));
 
     System.event(
       "token.approve_event",
@@ -275,7 +279,10 @@ export class Koin {
       key.set(account, 0);
       key.set(caller, 25);
       const allowance = this.allowances.get(key)!;
-      if (allowance.value >= amount) {
+
+      if (allowance.value == amount)
+        this.allowances.remove(key);
+      else if (allowance.value > amount) {
         allowance.value -= amount;
         this.allowances.put(key, allowance);
         return true;

--- a/contracts/koin/assembly/__tests__/koin.spec.ts
+++ b/contracts/koin/assembly/__tests__/koin.spec.ts
@@ -536,6 +536,18 @@ describe("koin", () => {
     expect(allowances.allowances.length).toBe(1);
     expect(Arrays.equal(allowances.allowances[0].spender, MOCK_ACCT3)).toBe(true);
     expect(allowances.allowances[0].value).toBe(30);
+
+    // Test setting an allowance to 0
+    MockVM.setAuthorities([mockAcc1Auth]);
+    approveArgs = new kcs4.approve_arguments(MOCK_ACCT1, MOCK_ACCT2, 0);
+    MockVM.setContractArguments(Protobuf.encode(approveArgs, kcs4.approve_arguments.encode));
+    koinContract.approve(approveArgs);
+
+    allowances = koinContract.get_allowances(new kcs4.get_allowances_arguments(MOCK_ACCT1, new Uint8Array(0), 10));
+    expect(Arrays.equal(allowances.owner, MOCK_ACCT1)).toBe(true);
+    expect(allowances.allowances.length).toBe(1);
+    expect(Arrays.equal(allowances.allowances[0].spender, MOCK_ACCT3)).toBe(true);
+    expect(allowances.allowances[0].value).toBe(20);
   });
 
   it("should require an approval", () => {

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -301,8 +301,10 @@ export class Vhp {
       key.set(caller, 25);
       const allowance = this.allowances.get(key)!;
 
-      if (allowance.value == amount)
+      if (allowance.value == amount) {
         this.allowances.remove(key);
+        return true
+      }
       if (allowance.value >= amount) {
         allowance.value -= amount;
         this.allowances.put(key, allowance);

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -278,7 +278,11 @@ export class Vhp {
     const key = new Uint8Array(50);
     key.set(args.owner, 0);
     key.set(args.spender, 25);
-    this.allowances.put(key, new vhp.balance_object(args.value));
+
+    if (args.value == 0)
+      this.allowances.remove(key);
+    else
+      this.allowances.put(key, new vhp.balance_object(args.value));
 
     System.event(
       "token.approve_event",
@@ -296,6 +300,9 @@ export class Vhp {
       key.set(account, 0);
       key.set(caller, 25);
       const allowance = this.allowances.get(key)!;
+
+      if (allowance.value == amount)
+        this.allowances.remove(key);
       if (allowance.value >= amount) {
         allowance.value -= amount;
         this.allowances.put(key, allowance);

--- a/contracts/vhp/assembly/Vhp.ts
+++ b/contracts/vhp/assembly/Vhp.ts
@@ -303,7 +303,7 @@ export class Vhp {
 
       if (allowance.value == amount) {
         this.allowances.remove(key);
-        return true
+        return true;
       }
       if (allowance.value >= amount) {
         allowance.value -= amount;

--- a/contracts/vhp/assembly/__tests__/vhp.spec.ts
+++ b/contracts/vhp/assembly/__tests__/vhp.spec.ts
@@ -680,6 +680,18 @@ describe("vhp", () => {
     expect(allowances.allowances.length).toBe(1);
     expect(Arrays.equal(allowances.allowances[0].spender, MOCK_ACCT3)).toBe(true);
     expect(allowances.allowances[0].value).toBe(30);
+
+    // Test setting an allowance to 0
+    MockVM.setAuthorities([mockAcc1Auth]);
+    approveArgs = new kcs4.approve_arguments(MOCK_ACCT1, MOCK_ACCT2, 0);
+    MockVM.setContractArguments(Protobuf.encode(approveArgs, kcs4.approve_arguments.encode));
+    vhpContract.approve(approveArgs);
+
+    allowances = vhpContract.get_allowances(new kcs4.get_allowances_arguments(MOCK_ACCT1, new Uint8Array(0), 10));
+    expect(Arrays.equal(allowances.owner, MOCK_ACCT1)).toBe(true);
+    expect(allowances.allowances.length).toBe(1);
+    expect(Arrays.equal(allowances.allowances[0].spender, MOCK_ACCT3)).toBe(true);
+    expect(allowances.allowances[0].value).toBe(20);
   });
 
   it("should require an approval", () => {


### PR DESCRIPTION
## Brief description

Cleanup 0 value allowance objects so they are not returned in `get_allowances`.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
